### PR TITLE
Fix Postgres port 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,8 @@ Features:
 - **Active Development**: Continuously updated to keep up with the latest best practices and features in the ctrlplane ecosystem.
 
 Get started with ctrlplanedev/ctrlplane-charts today and supercharge your Kubernetes deployments!
+
+```bash
+helm repo add ctrlcharts https://charts.ctrlplane.dev
+helm repo update
+```

--- a/charts/ctrlplane/Chart.yaml
+++ b/charts/ctrlplane/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ctrlplane
 description: Ctrlplane Helm chart for Kubernetes
 type: application
-version: 0.1.37
+version: 0.1.38
 appVersion: "1.16.0"
 
 maintainers:

--- a/charts/ctrlplane/templates/_postgresql.tpl
+++ b/charts/ctrlplane/templates/_postgresql.tpl
@@ -1,3 +1,4 @@
 {{- define "ctrlplane.postgresqlUrl" -}}
-{{- printf "postgresql://%s:%s@%s:%s/%s" .Values.global.postgresql.user .Values.global.postgresql.password .Values.global.postgresql.host .Values.global.postgresql.port .Values.global.postgresql.database -}}
+{{- printf "postgresql://%s:%s@%s:%s/%s" .Values.global.postgresql.user .Values.global.postgresql.password .Values.global.postgresql.host (toString .Values.global.postgresql.port) .Values.global.postgresql.database -}}
 {{- end -}}
+

--- a/charts/ctrlplane/templates/_postgresql.tpl
+++ b/charts/ctrlplane/templates/_postgresql.tpl
@@ -1,4 +1,3 @@
 {{- define "ctrlplane.postgresqlUrl" -}}
 {{- printf "postgresql://%s:%s@%s:%s/%s" .Values.global.postgresql.user .Values.global.postgresql.password .Values.global.postgresql.host (toString .Values.global.postgresql.port) .Values.global.postgresql.database -}}
 {{- end -}}
-


### PR DESCRIPTION
This change handles both string and integer values for the PostgreSQL port so this helm chart can be both manually applied and applied via terraform helm provider and avoid formatting issues like: (%!s(int64=6379))