### PR TITLE
fix: Add expired env checker job

### DIFF
--- a/charts/ctrlplane/Chart.yaml
+++ b/charts/ctrlplane/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ctrlplane
 description: Ctrlplane Helm chart for Kubernetes
 type: application
-version: 0.2.6
+version: 0.2.7
 appVersion: "1.16.0"
 
 maintainers:

--- a/charts/ctrlplane/charts/jobs/templates/expired-env-checker.yaml
+++ b/charts/ctrlplane/charts/jobs/templates/expired-env-checker.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "jobs.fullname" . }}-expired-env-checker
+  labels:
+    {{- if .Values.cron.labels -}}
+    {{-   toYaml .Values.cron.labels | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.cron.annotations -}}
+    {{-   toYaml .Values.cron.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  concurrencyPolicy: {{ .Values.cron.concurrencyPolicy }}
+  schedule: {{ .Values.cron.schedule | quote }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: expired-env-checker
+              image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command: ["node"]
+              args: ["index.js", "-r", "-j expired-env-checker"]
+              env:
+                - name: REDIS_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Release.Name }}-connections
+                      key: REDIS_URL
+                - name: POSTGRES_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Release.Name }}-connections
+                      key: POSTGRES_URL
+                - name: VARIABLES_AES_256_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Release.Name }}-encryption-key
+                      key: AES_256_KEY
+                {{- include "ctrlplane.extraEnv" . | nindent 16 }}
+                {{- include "ctrlplane.extraEnvFrom" (dict "root" $ "local" .) | nindent 16 }}
+              resources:
+                {{- toYaml .Values.resources | nindent 16 }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new Kubernetes CronJob for scheduled checks of expired environments, enhancing management capabilities.
  
- **Version Update**
	- Updated the version of the `ctrlplane` Helm chart from 0.2.6 to 0.2.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->