### PR TITLE
chore: add policy v2 flag

### DIFF
--- a/charts/ctrlplane/Chart.yaml
+++ b/charts/ctrlplane/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ctrlplane
 description: Ctrlplane Helm chart for Kubernetes
 type: application
-version: 0.3.12
+version: 0.3.13
 appVersion: "1.16.0"
 
 maintainers:

--- a/charts/ctrlplane/charts/event-worker/templates/deployment.yaml
+++ b/charts/ctrlplane/charts/event-worker/templates/deployment.yaml
@@ -103,5 +103,7 @@ spec:
             {{- end }}
             {{- include "ctrlplane.extraEnv" . | nindent 12 }}
             {{- include "ctrlplane.extraEnvFrom" (dict "root" $ "local" .) | nindent 12 }}
+            - name: ENABLE_NEW_POLICY_ENGINE
+              value: {{ .Values.global.enableNewPolicyEngine | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/ctrlplane/charts/webservice/templates/deployment.yaml
+++ b/charts/ctrlplane/charts/webservice/templates/deployment.yaml
@@ -123,6 +123,8 @@ spec:
                   name: {{ .secretRef }}
                   key: GITHUB_WEBHOOK_SECRET
                   optional: true
+            - name: ENABLE_NEW_POLICY_ENGINE
+              value: {{ .Values.global.enableNewPolicyEngine | quote }}
             # - name: OTEL_EXPORTER_OTLP_ENDPOINT
               # value: http://{{ $.Release.Name }}-otel:4318
             {{- end }}

--- a/charts/ctrlplane/charts/webservice/templates/deployment.yaml
+++ b/charts/ctrlplane/charts/webservice/templates/deployment.yaml
@@ -123,11 +123,11 @@ spec:
                   name: {{ .secretRef }}
                   key: GITHUB_WEBHOOK_SECRET
                   optional: true
-            - name: ENABLE_NEW_POLICY_ENGINE
-              value: {{ .Values.global.enableNewPolicyEngine | quote }}
             # - name: OTEL_EXPORTER_OTLP_ENDPOINT
               # value: http://{{ $.Release.Name }}-otel:4318
             {{- end }}
+            - name: ENABLE_NEW_POLICY_ENGINE
+              value: {{ .Values.global.enableNewPolicyEngine | quote }}
             {{- with (include "ctrlplane.azureApp" . | fromYaml) }}
             - name: AZURE_APP_CLIENT_ID
               value: {{ .clientId | quote }}

--- a/charts/ctrlplane/values.yaml
+++ b/charts/ctrlplane/values.yaml
@@ -3,6 +3,7 @@ global:
 
   extraEnvFrom: {}
   extraEnv: {}
+  enableNewPolicyEngine: false
 
   authProviders:
     google:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new global configuration option to enable or disable the new policy engine.
  - Added support for configuring the new policy engine via environment variables in both event-worker and webservice deployments.

- **Chores**
  - Bumped the Helm chart version from 0.3.12 to 0.3.13.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->