### PR TITLE
chore: init event queue

### DIFF
--- a/charts/ctrlplane/Chart.lock
+++ b/charts/ctrlplane/Chart.lock
@@ -11,11 +11,14 @@ dependencies:
 - name: event-worker
   repository: file://charts/event-worker
   version: 0.1.7
+- name: event-queue
+  repository: file://charts/event-queue
+  version: 0.1.7
 - name: otel
   repository: file://charts/otel
   version: 0.1.0
 - name: pty-proxy
   repository: file://charts/pty-proxy
   version: 0.1.7
-digest: sha256:ee36f31f10040547ecb5a25a32c45a5bc25f70bfca315cc693e05c3efe4253d9
-generated: "2024-11-14T14:15:19.282865-05:00"
+digest: sha256:696d4172a4ce1e477df94406da1ee21a05680dc5734eeeec89ee59fc1810f376
+generated: "2025-09-15T17:19:06.843928-04:00"

--- a/charts/ctrlplane/Chart.yaml
+++ b/charts/ctrlplane/Chart.yaml
@@ -27,6 +27,10 @@ dependencies:
     condition: event-worker.install
     version: "*.*.*"
     repository: "file://charts/event-worker"
+  - name: event-queue
+    condition: event-queue.install
+    version: "*.*.*"
+    repository: "file://charts/event-queue"
   - name: otel
     condition: otel.install
     version: "*.*.*"

--- a/charts/ctrlplane/Chart.yaml
+++ b/charts/ctrlplane/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ctrlplane
 description: Ctrlplane Helm chart for Kubernetes
 type: application
-version: 0.3.14
+version: 0.4.0
 appVersion: "1.16.0"
 
 maintainers:

--- a/charts/ctrlplane/charts/event-queue/.helmignore
+++ b/charts/ctrlplane/charts/event-queue/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/ctrlplane/charts/event-queue/Chart.yaml
+++ b/charts/ctrlplane/charts/event-queue/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: event-queue
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.7
+appVersion: "1.16.0"

--- a/charts/ctrlplane/charts/event-queue/templates/_helpers.tpl
+++ b/charts/ctrlplane/charts/event-queue/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "event-queue.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "event-queue.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "event-queue.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "event-queue.labels" -}}
+helm.sh/chart: {{ include "event-queue.chart" . }}
+{{ include "event-queue.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "event-queue.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "event-queue.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "event-queue.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "event-queue.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/ctrlplane/charts/event-queue/templates/deployment.yaml
+++ b/charts/ctrlplane/charts/event-queue/templates/deployment.yaml
@@ -1,0 +1,96 @@
+{{- $imageCfg := dict "global" $.Values.global.image "local" $.Values.image -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "event-queue.fullname" . }}
+  labels:
+    {{- include "event-queue.labels" . | nindent 4 }}
+    {{- if .Values.deployment.labels -}}
+    {{-   toYaml .Values.deployment.labels | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.deployment.annotations -}}
+    {{-   toYaml .Values.deployment.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  replicas: {{ .Values.replica }}
+  selector:
+    matchLabels:
+      {{- include "ctrlplane.selectorLabels" $ | nindent 6 }}
+      {{- include "event-queue.labels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "event-queue.labels" . | nindent 8 }}
+      annotations:
+        {{- if .Values.pod.annotations -}}
+        {{-   toYaml .Values.pod.annotations | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "event-queue.serviceAccountName" . }}
+      {{- if .tolerations }}
+      tolerations:
+        {{- toYaml .tolerations | nindent 8 }}
+      {{- end }}
+      {{- include "ctrlplane.nodeSelector" . | nindent 6 }}
+      {{- include "ctrlplane.priorityClassName" . | nindent 6 }}
+      {{- include "ctrlplane.podSecurityContext" .Values.pod.securityContext | nindent 6 }}
+      containers:
+        - name: event-queue
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          ports:
+            - name: health
+              containerPort: 3123
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            failureThreshold: 20
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          env:
+            - name: KAFKA_BROKERS
+              value: {{ .Values.global.kafkaBrokers | quote }}
+            - name: POSTGRES_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-connections
+                  key: POSTGRES_URL
+            - name: VARIABLES_AES_256_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-encryption-key
+                  key: AES_256_KEY
+            {{- with (include "ctrlplane.githubBot" . | fromYaml) }}
+            - name: GITHUB_BOT_APP_ID
+              value: {{ .appId | quote }}
+            - name: GITHUB_BOT_CLIENT_ID
+              value: {{ .clientId | quote }}
+            - name: GITHUB_BOT_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .secretRef }}
+                  key: GITHUB_BOT_CLIENT_SECRET
+                  optional: true
+            - name: GITHUB_BOT_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .secretRef }}
+                  key: GITHUB_BOT_PRIVATE_KEY
+                  optional: true
+            - name: GITHUB_BOT_NAME
+              value: {{ .name }}
+            {{- end }}
+            {{- include "ctrlplane.extraEnv" . | nindent 12 }}
+            {{- include "ctrlplane.extraEnvFrom" (dict "root" $ "local" .) | nindent 12 }}
+            - name: ENABLE_NEW_POLICY_ENGINE
+              value: {{ .Values.global.enableNewPolicyEngine | quote }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/ctrlplane/charts/event-queue/templates/hpa.yaml
+++ b/charts/ctrlplane/charts/event-queue/templates/hpa.yaml
@@ -1,0 +1,28 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "event-queue.fullname" . }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "event-queue.labels" . | nindent 4 }}
+    {{- if .Values.hpa.labels -}}
+    {{-   toYaml .Values.hpa.labels | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.hpa.annotations -}}
+    {{-   toYaml .Values.hpa.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "event-queue.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 70

--- a/charts/ctrlplane/charts/event-queue/templates/serviceaccount.yaml
+++ b/charts/ctrlplane/charts/event-queue/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "event-queue.serviceAccountName" . }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "event-queue.labels" . | nindent 4 }}
+    {{- if .Values.serviceAccount.labels -}}
+    {{-   toYaml .Values.serviceAccount.labels | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.serviceAccount.annotations -}}
+    {{-   toYaml .Values.serviceAccount.annotations | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/ctrlplane/charts/event-queue/values.yaml
+++ b/charts/ctrlplane/charts/event-queue/values.yaml
@@ -1,0 +1,39 @@
+nameOverride: ""
+fullnameOverride: ""
+
+replica: 1
+
+image:
+  repository: ctrlplane/event-queue
+  tag: latest
+  pullPolicy: Always
+
+extraEnv: {}
+extraEnvFrom: {}
+
+deployment:
+  labels: {}
+  annotations: {}
+
+hpa:
+  labels: {}
+  annotations: {}
+  minReplicas: 1
+  maxReplicas: 5
+
+tolerations: []
+pod: {}
+
+serviceAccount:
+  create: false
+  name: ""
+  labels: {}
+  annotations: {}
+
+resources:
+  requests:
+    cpu: 1000m
+    memory: 1Gi
+  limits:
+    cpu: 4000m
+    memory: 4Gi

--- a/charts/ctrlplane/values.yaml
+++ b/charts/ctrlplane/values.yaml
@@ -66,6 +66,9 @@ ingress:
 event-worker:
   install: true
 
+event-queue:
+  install: true
+
 otel:
   install: true
 

--- a/charts/ctrlplane/values.yaml
+++ b/charts/ctrlplane/values.yaml
@@ -32,6 +32,8 @@ global:
     port: "5432"
     database: "ctrlplane"
 
+  kafkaBrokers: localhost:9092
+
   integrations:
     github:
       url: "https://github.com"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added an event-queue component with deployment, service account (optional), and Horizontal Pod Autoscaler.
  - New configurable defaults: image, replicas, resources, HPA, tolerations, labels/annotations, extra env and envFrom.
  - Added helper templates and packaging ignores to standardize naming/labels and exclude common artifacts.
  - Added a default global Kafka brokers setting.

- Chores
  - Bumped control-plane chart version to 0.4.0 and declared event-queue as a chart dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->