### PR TITLE
init

### DIFF
--- a/charts/ctrlplane/Chart.yaml
+++ b/charts/ctrlplane/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ctrlplane
 description: Ctrlplane Helm chart for Kubernetes
 type: application
-version: 0.4.4
+version: 0.4.5
 appVersion: "1.16.0"
 
 maintainers:
@@ -39,3 +39,7 @@ dependencies:
     condition: pty-proxy.install
     version: "*.*.*"
     repository: "file://charts/pty-proxy"
+  - name: workspace-engine
+    condition: workspace-engine.install
+    version: "*.*.*"
+    repository: "file://charts/workspace-engine"

--- a/charts/ctrlplane/charts/event-queue/templates/_helpers.tpl
+++ b/charts/ctrlplane/charts/event-queue/templates/_helpers.tpl
@@ -60,3 +60,36 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{ define "pgbouncer.ini" }}
+
+{{/* [databases] section */}}
+{{- if $.Values.databases }}
+  {{ printf "[databases]" }}
+  {{- range $key, $value := .Values.databases }}
+    {{ $key }} ={{ range $k, $v := $value }} {{ $k }}={{ $v }}{{ end }}
+  {{- end }}
+{{- end }}
+
+{{/* [pgbouncer] section */}}
+{{- if $.Values.pgbouncer }}
+  {{ printf "[pgbouncer]" }}
+  {{- range $k, $v := $.Values.pgbouncer }}
+    {{ $k }} = {{ $v }}
+  {{- end }}
+{{- end }}
+
+{{/* [users] section */}}
+{{- if $.Values.users }}
+  {{ printf "[users]" }}
+  {{- range $k, $v := $.Values.users }}
+    {{ $k }} = {{ $v }}
+  {{- end }}
+{{- end }}
+
+{{/* include is a special configuration within [pgbouncer] section */}}
+{{- if $.Values.include }}
+  {{ printf "%s %s" "%include" $.Values.include }}
+{{- end }}
+
+{{ end }}

--- a/charts/ctrlplane/charts/event-queue/templates/deployment.yaml
+++ b/charts/ctrlplane/charts/event-queue/templates/deployment.yaml
@@ -102,3 +102,16 @@ spec:
               value: {{ .Values.global.enableNewPolicyEngine | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        - name: pgbouncer
+          image: "{{ .Values.pgbouncer.image.repository }}:{{ .Values.pgbouncer.image.tag }}"
+          imagePullPolicy: "{{ .Values.pgbouncer.image.pullPolicy }}"
+          ports:
+            - name: pgbouncer
+              containerPort: {{ .Values.pgbouncer.internalPort }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/pgbouncer
+              readOnly: true
+          resources:
+            {{- toYaml .Values.pgbouncer.resources | nindent 12 }}
+

--- a/charts/ctrlplane/charts/event-queue/templates/pgbouncer.yaml
+++ b/charts/ctrlplane/charts/event-queue/templates/pgbouncer.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "pgbouncer.configFile" . }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "pgbouncer.labels" . | nindent 4 }}
+data:
+  pgbouncer.ini: |-
+{{- include "pgbouncer.ini" . | indent 4}}

--- a/charts/ctrlplane/charts/event-queue/values.yaml
+++ b/charts/ctrlplane/charts/event-queue/values.yaml
@@ -8,6 +8,24 @@ image:
   tag: latest
   pullPolicy: Always
 
+pgbouncer:
+  image:
+    repository: ctrlplane/pgbouncer
+    tag: latest
+    pullPolicy: Always
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  internalPort: 6379
+  config:
+    listen_addr: 0.0.0.0
+    listen_port: 6432
+    unix_socket_dir: ""
+
 extraEnv: {}
 extraEnvFrom: {}
 

--- a/charts/ctrlplane/charts/workspace-engine/.helmignore
+++ b/charts/ctrlplane/charts/workspace-engine/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/ctrlplane/charts/workspace-engine/Chart.yaml
+++ b/charts/ctrlplane/charts/workspace-engine/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: workspace-engine
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/charts/ctrlplane/charts/workspace-engine/templates/_helpers.tpl
+++ b/charts/ctrlplane/charts/workspace-engine/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "workspace-engine.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "workspace-engine.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "workspace-engine.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "workspace-engine.labels" -}}
+helm.sh/chart: {{ include "workspace-engine.chart" . }}
+{{ include "workspace-engine.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "workspace-engine.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "workspace-engine.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "workspace-engine.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "workspace-engine.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+

--- a/charts/ctrlplane/charts/workspace-engine/templates/serviceaccount.yaml
+++ b/charts/ctrlplane/charts/workspace-engine/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "workspace-engine.serviceAccountName" . }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "workspace-engine.labels" . | nindent 4 }}
+    {{- if .Values.serviceAccount.labels -}}
+    {{-   toYaml .Values.serviceAccount.labels | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.serviceAccount.annotations -}}
+    {{-   toYaml .Values.serviceAccount.annotations | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/ctrlplane/charts/workspace-engine/templates/statefulset.yaml
+++ b/charts/ctrlplane/charts/workspace-engine/templates/statefulset.yaml
@@ -1,10 +1,10 @@
 {{- $imageCfg := dict "global" $.Values.global.image "local" $.Values.image -}}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
-  name: {{ include "event-queue.fullname" . }}
+  name: {{ .Release.Name }}-engine
   labels:
-    {{- include "event-queue.labels" . | nindent 4 }}
+    {{- include "workspace-engine.labels" . | nindent 4 }}
     {{- if .Values.deployment.labels -}}
     {{-   toYaml .Values.deployment.labels | nindent 4 }}
     {{- end }}
@@ -13,21 +13,22 @@ metadata:
     {{-   toYaml .Values.deployment.annotations | nindent 4 }}
     {{- end }}
 spec:
+  serviceName: {{ .Release.Name }}-engine
   replicas: {{ .Values.replica }}
   selector:
     matchLabels:
       {{- include "ctrlplane.selectorLabels" $ | nindent 6 }}
-      {{- include "event-queue.labels" . | nindent 6 }}
+      {{- include "workspace-engine.labels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "event-queue.labels" . | nindent 8 }}
+        {{- include "workspace-engine.labels" . | nindent 8 }}
       annotations:
         {{- if .Values.pod.annotations -}}
         {{-   toYaml .Values.pod.annotations | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ include "event-queue.serviceAccountName" . }}
+      serviceAccountName: {{ include "workspace-engine.serviceAccountName" . }}
       {{- if .tolerations }}
       tolerations:
         {{- toYaml .tolerations | nindent 8 }}
@@ -36,31 +37,23 @@ spec:
       {{- include "ctrlplane.priorityClassName" . | nindent 6 }}
       {{- include "ctrlplane.podSecurityContext" .Values.pod.securityContext | nindent 6 }}
       containers:
-        - name: event-queue
+        - name: workspace-engine
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           ports:
-            - name: health
-              containerPort: 3124
+            - name: http2
+              containerPort: 8081
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: health
-            initialDelaySeconds: 15
-            periodSeconds: 60
-            timeoutSeconds: 10
-            failureThreshold: 10
-          readinessProbe:
-            httpGet:
-              path: /healthz
-              port: health
-            initialDelaySeconds: 15
-            periodSeconds: 60
-            timeoutSeconds: 10
-            failureThreshold: 10
           env:
             - name: KAFKA_BROKERS
               value: {{ .Values.global.kafkaBrokers | quote }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KAFKA_PARTITION_ID
+              value: "$(echo $POD_NAME | sed 's/.*-//')"
+            - name: GRPC_PORT
+              value: {{ .Values.grpc.port | quote }}
             - name: REDIS_URL
               valueFrom:
                 secretKeyRef:
@@ -96,33 +89,9 @@ spec:
             - name: GITHUB_BOT_NAME
               value: {{ .name }}
             {{- end }}
-            - name: WORKSPACE_ENGINE_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: WORKSPACE_ENGINE_STATEFUL_SET_NAME
-              value: {{ .Chart.Name }}-engine
-            - name: WORKSPACE_ENGINE_HEADLESS_SERVICE
-              value: {{ .Release.Name }}-engine
-            - name: WORKSPACE_ENGINE_PORT
-              value: "8081"
-            
             {{- include "ctrlplane.extraEnv" . | nindent 12 }}
             {{- include "ctrlplane.extraEnvFrom" (dict "root" $ "local" .) | nindent 12 }}
             - name: ENABLE_NEW_POLICY_ENGINE
               value: {{ .Values.global.enableNewPolicyEngine | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-        - name: pgbouncer
-          image: "{{ .Values.pgbouncer.image.repository }}:{{ .Values.pgbouncer.image.tag }}"
-          imagePullPolicy: "{{ .Values.pgbouncer.image.pullPolicy }}"
-          ports:
-            - name: pgbouncer
-              containerPort: {{ .Values.pgbouncer.internalPort }}
-          volumeMounts:
-            - name: config
-              mountPath: /etc/pgbouncer
-              readOnly: true
-          resources:
-            {{- toYaml .Values.pgbouncer.resources | nindent 12 }}
-

--- a/charts/ctrlplane/charts/workspace-engine/values.yaml
+++ b/charts/ctrlplane/charts/workspace-engine/values.yaml
@@ -1,0 +1,29 @@
+nameOverride: ""
+fullnameOverride: ""
+
+replica: 1
+
+image:
+  repository: ctrlplane/workspace-engine
+  tag: latest
+  pullPolicy: Always
+
+extraEnv: {}
+extraEnvFrom: {}
+
+tolerations: []
+pod: {}
+
+serviceAccount:
+  create: false
+  name: ""
+  labels: {}
+  annotations: {}
+
+resources:
+  requests:
+    cpu: 1000m
+    memory: 1Gi
+  limits:
+    cpu: 4000m
+    memory: 4Gi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds optional PgBouncer sidecar to the event-queue pod, with auto-generated pgbouncer.ini and configurable values (image, resources, port, core settings).
  * Introduces a new workspace-engine chart with defaults, service account and StatefulSet templates for deploying the workspace engine.
  * Bumps ctrlplane chart version and adds workspace-engine as an optional chart dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->