### PR TITLE
chore: change otel deployment to daemonset

### DIFF
--- a/charts/ctrlplane/Chart.yaml
+++ b/charts/ctrlplane/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ctrlplane
 description: Ctrlplane Helm chart for Kubernetes
 type: application
-version: 0.7.1
+version: 0.8.0
 appVersion: "1.0.0"
 
 maintainers:

--- a/charts/ctrlplane/charts/otel/templates/daemonset.yaml
+++ b/charts/ctrlplane/charts/otel/templates/daemonset.yaml
@@ -1,18 +1,17 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: {{ include "otel.fullname" . }}
   labels:
     {{- include "otel.labels" . | nindent 4 }}
-    {{- if .Values.deployment.labels -}}
-    {{-   toYaml .Values.deployment.labels | nindent 4 }}
+    {{- if .Values.daemonset.labels -}}
+    {{-   toYaml .Values.daemonset.labels | nindent 4 }}
     {{- end }}
   annotations:
-    {{- if .Values.deployment.annotations -}}
-    {{-   toYaml .Values.deployment.annotations | nindent 4 }}
+    {{- if .Values.daemonset.annotations -}}
+    {{-   toYaml .Values.daemonset.annotations | nindent 4 }}
     {{- end }}
 spec:
-  replicas: 1
   selector:
     matchLabels:
       {{- include "ctrlplane.selectorLabels" $ | nindent 6 }}

--- a/charts/ctrlplane/charts/otel/values.yaml
+++ b/charts/ctrlplane/charts/otel/values.yaml
@@ -50,7 +50,7 @@ common:
   labels: {}
   annotations: {}
 
-deployment:
+daemonset:
   labels: {}
   annotations: {}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated OpenTelemetry workload to run as a DaemonSet instead of a Deployment, removed replica settings, and aligned configuration keys accordingly.
  * Bumped chart version to 0.8.0 to reflect the rollout of these configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->