### PR TITLE
Initial `ctrlc-sync` helm chart

### DIFF
--- a/charts/ctrlc-sync/.helmignore
+++ b/charts/ctrlc-sync/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/ctrlc-sync/Chart.yaml
+++ b/charts/ctrlc-sync/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: ctrlc-sync
+description: A Helm chart for ctrlc sync jobs in Kubernetes
+type: application
+version: 0.1.0
+appVersion: "v0.16.2"
+
+maintainers:
+  - name: ctrlplane
+    email: support@ctrlplane.com
+    url: https://ctrlplane.dev

--- a/charts/ctrlc-sync/templates/_env.tpl
+++ b/charts/ctrlc-sync/templates/_env.tpl
@@ -1,0 +1,46 @@
+{{- define "ctrlc-sync.envs" -}}
+{{- if kindIs "map" .Values.ctrlc.apiKey -}}
+- name: CTRLPLANE_API_KEY
+{{- toYaml .Values.ctrlc.apiKey | nindent 2 }}
+{{- else -}}
+- name: CTRLPLANE_API_KEY
+  valueFrom:
+    secretKeyRef:
+      name: "{{ include "ctrlc-sync.secretname" . }}"
+      key: "apiKey"
+{{- end }}
+
+{{- if kindIs "map" .Values.ctrlc.workspaceID }}
+- name: CTRLPLANE_WORKSPACE
+{{- toYaml .Values.ctrlc.workspaceID | nindent 2 }}
+{{- else }}
+- name: CTRLPLANE_WORKSPACE
+  value: "{{ .Values.ctrlc.workspaceID }}"
+{{- end }}
+
+{{- if kindIs "map" .Values.ctrlc.apiURL }}
+- name: CTRLPLANE_URL
+{{- toYaml .Values.ctrlc.apiURL | nindent 2 }}
+{{- else }}
+- name: CTRLPLANE_URL
+  value: "{{ .Values.ctrlc.apiURL }}"
+{{- end }}
+
+{{- if kindIs "map" .Values.ctrlc.identifier }}
+- name: CTRLPLANE_CLUSTER_IDENTIFIER
+{{- toYaml .Values.ctrlc.identifier | nindent 2 }}
+{{- else }}
+- name: CTRLPLANE_CLUSTER_IDENTIFIER
+  value: "{{ .Values.ctrlc.identifier }}"
+{{- end }}
+
+{{- if kindIs "map" .Values.ctrlc.logLevel }}
+- name: CTRLPLANE_LOG_LEVEL
+{{- toYaml .Values.ctrlc.logLevel | nindent 2 }}
+{{- else }}
+- name: CTRLPLANE_LOG_LEVEL
+  value: "{{ .Values.ctrlc.logLevel }}"
+{{- end }}
+
+{{- end }}
+

--- a/charts/ctrlc-sync/templates/_helpers.tpl
+++ b/charts/ctrlc-sync/templates/_helpers.tpl
@@ -1,0 +1,75 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ctrlc-sync.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ctrlc-sync.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ctrlc-sync.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "ctrlc-sync.secretname" -}}
+{{- printf "%s-secret" (include "ctrlc-sync.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+
+{{/*
+Common labels
+*/}}
+{{- define "ctrlc-sync.labels" -}}
+helm.sh/chart: {{ include "ctrlc-sync.chart" . }}
+{{ include "ctrlc-sync.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ctrlc-sync.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ctrlc-sync.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "ctrlc-sync.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "ctrlc-sync.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "ctrlc-sync.clusterRole.k8s" -}}
+{{- printf "%s-k8s-sync-role" (include "ctrlc-sync.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "ctrlc-sync.clusterRoleBinding.k8s" -}}
+{{- printf "%s-k8s-sync-rolebinding" (include "ctrlc-sync.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}

--- a/charts/ctrlc-sync/templates/clusterrolebinding.yaml
+++ b/charts/ctrlc-sync/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "ctrlc-sync.clusterRoleBinding.k8s" . }}
+  labels:
+    {{- include "ctrlc-sync.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "ctrlc-sync.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "ctrlc-sync.clusterRole.k8s" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/ctrlc-sync/templates/clusterroles.yaml
+++ b/charts/ctrlc-sync/templates/clusterroles.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.rbac.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "ctrlc-sync.clusterRole.k8s" . }}
+  labels:
+    {{- include "ctrlc-sync.labels" . | nindent 4 }}
+rules:
+- apiGroups: ["apps"]
+  resources: ["statefulsets", "deployments"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "list", "watch"]
+{{- end }}

--- a/charts/ctrlc-sync/templates/cronjob.yaml
+++ b/charts/ctrlc-sync/templates/cronjob.yaml
@@ -45,6 +45,7 @@ spec:
             {{- with .Values.podLabels }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+        restartPolicy: OnFailure
         spec:
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:

--- a/charts/ctrlc-sync/templates/cronjob.yaml
+++ b/charts/ctrlc-sync/templates/cronjob.yaml
@@ -1,0 +1,94 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "ctrlc-sync.fullname" . }}
+  labels:
+    {{- include "ctrlc-sync.labels" . | nindent 4 }}
+spec:
+  schedule: "{{ .Values.cron.schedule }}"
+  {{- if .Values.cron.timeZone }}
+  timeZone: "{{ .Values.cron.timeZone }}"
+  {{- end }}
+  concurrencyPolicy: "{{ .Values.cron.concurrencyPolicy }}"
+  {{- if .Values.cron.startingDeadlineSeconds }}
+  startingDeadlineSeconds: {{ .Values.cron.startingDeadlineSeconds }}
+  {{- end }}
+  successfulJobsHistoryLimit: {{ .Values.cron.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.cron.failedJobsHistoryLimit }}
+  jobTemplate:
+    metadata:
+      {{- with .Values.jobAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "ctrlc-sync.labels" . | nindent 8 }}
+        {{- with .Values.jobLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      backoffLimit: {{ .Values.job.backoffLimit }}
+      {{- if .Values.job.activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ .Values.job.activeDeadlineSeconds }}
+      {{- end }}
+      {{- if .Values.job.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.job.ttlSecondsAfterFinished }}
+      {{- end }}
+      template:
+        metadata:
+          {{- with .Values.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          labels:
+            {{- include "ctrlc-sync.labels" . | nindent 12 }}
+            {{- with .Values.podLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        spec:
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          serviceAccountName: {{ include "ctrlc-sync.serviceAccountName" . }}
+          {{- with .Values.podSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          containers:
+            - name: {{ .Chart.Name }}
+              {{- with .Values.securityContext }}
+              securityContext:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command: ["ctrlc"]
+              args: ["sync", "kubernetes"]
+              env:
+                {{- include "ctrlc-sync.envs" . | nindent 16 }}
+              {{- with .Values.resources }}
+              resources:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+              {{- with .Values.volumeMounts }}
+              volumeMounts:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+          {{- with .Values.volumes }}
+          volumes:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+

--- a/charts/ctrlc-sync/templates/cronjob.yaml
+++ b/charts/ctrlc-sync/templates/cronjob.yaml
@@ -10,7 +10,7 @@ spec:
   timeZone: "{{ .Values.cron.timeZone }}"
   {{- end }}
   concurrencyPolicy: "{{ .Values.cron.concurrencyPolicy }}"
-  {{- if .Values.cron.startingDeadlineSeconds }}
+  {{- if ne .Values.cron.startingDeadlineSeconds nil }}
   startingDeadlineSeconds: {{ .Values.cron.startingDeadlineSeconds }}
   {{- end }}
   successfulJobsHistoryLimit: {{ .Values.cron.successfulJobsHistoryLimit }}
@@ -28,10 +28,10 @@ spec:
         {{- end }}
     spec:
       backoffLimit: {{ .Values.job.backoffLimit }}
-      {{- if .Values.job.activeDeadlineSeconds }}
+      {{- if ne .Values.job.activeDeadlineSeconds nil }}
       activeDeadlineSeconds: {{ .Values.job.activeDeadlineSeconds }}
       {{- end }}
-      {{- if .Values.job.ttlSecondsAfterFinished }}
+      {{- if ne .Values.job.ttlSecondsAfterFinished nil }}
       ttlSecondsAfterFinished: {{ .Values.job.ttlSecondsAfterFinished }}
       {{- end }}
       template:

--- a/charts/ctrlc-sync/templates/cronjob.yaml
+++ b/charts/ctrlc-sync/templates/cronjob.yaml
@@ -45,7 +45,6 @@ spec:
             {{- with .Values.podLabels }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-        restartPolicy: OnFailure
         spec:
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:
@@ -56,6 +55,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          restartPolicy: OnFailure
           containers:
             - name: {{ .Chart.Name }}
               {{- with .Values.securityContext }}

--- a/charts/ctrlc-sync/templates/secret.yaml
+++ b/charts/ctrlc-sync/templates/secret.yaml
@@ -1,0 +1,10 @@
+{{- if not (kindIs "map" .Values.ctrlc.apiKey ) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ctrlc-sync.secretname" . }}
+  labels:
+    {{- include "ctrlc-sync.labels" . | nindent 4 }}
+data:
+  apiKey: {{ .Values.ctrlc.apiKey | b64enc }}
+{{- end }}

--- a/charts/ctrlc-sync/templates/serviceaccount.yaml
+++ b/charts/ctrlc-sync/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ctrlc-sync.serviceAccountName" . }}
+  labels:
+    {{- include "ctrlc-sync.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/ctrlc-sync/values.yaml
+++ b/charts/ctrlc-sync/values.yaml
@@ -91,14 +91,14 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
-# Additional volumes on the output Deployment definition.
+# Additional volumes on the output definition.
 volumes: []
 # - name: foo
 #   secret:
 #     secretName: mysecret
 #     optional: false
 
-# Additional volumeMounts on the output Deployment definition.
+# Additional volumeMounts on the output definition.
 volumeMounts: []
 # - name: foo
 #   mountPath: "/etc/foo"

--- a/charts/ctrlc-sync/values.yaml
+++ b/charts/ctrlc-sync/values.yaml
@@ -1,0 +1,111 @@
+ctrlc:
+  target: "kubernetes"
+  # All of following values under the ctrlc config from this point
+  # can be provided directly as strings or as valueFrom
+  # reference -> https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#envfromsource-v1-core
+  # # for example:
+  # apiKey:
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: ctrlplane-api-key
+  #       key: api-key
+  identifier: ""
+  name: ""
+  workspaceID: ""
+  apiURL: ""
+  apiKey: ""
+  logLevel: "info"
+
+cron:
+  schedule: "*/1 * * * *"
+  # timeZone: ""
+  concurrencyPolicy: "Forbid"
+  # startingDeadlineSeconds: 300
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+
+job:
+  backoffLimit: 6
+  # activeDeadlineSeconds: 300
+  # ttlSecondsAfterFinished: 0
+
+rbac:
+  enabled: true
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  repository: ctrlplane/cli
+  # This sets the pull policy for images.
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+jobAnnotations: {}
+jobLabels: {}
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/ctrlc-sync/values.yaml
+++ b/charts/ctrlc-sync/values.yaml
@@ -68,16 +68,19 @@ podAnnotations: {}
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 podLabels: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  fsGroup: 2000
+  seccompProfile:
+    type: RuntimeDefault
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsUser: 1000
+  runAsNonRoot: true
+  capabilities:
+    drop:
+      - ALL
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/ctrlc-sync/values.yaml
+++ b/charts/ctrlc-sync/values.yaml
@@ -2,7 +2,7 @@ ctrlc:
   target: "kubernetes"
   # All of following values under the ctrlc config from this point
   # can be provided directly as strings or as valueFrom
-  # reference -> https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#envfromsource-v1-core
+  # reference -> https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#envvarsource-v1-core
   # # for example:
   # apiKey:
   #   valueFrom:


### PR DESCRIPTION
This is an initial release/setup. 

I have plans to allow you to configure the other scanners, making more of the settings modular.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Helm chart to deploy ctrlc-sync with chart metadata and packaging.
  * Optional RBAC support: ClusterRole and ClusterRoleBinding with service account handling.
  * Flexible API key support: secret-backed or literal values and configurable environment variables.
  * CronJob-based sync jobs with schedule, concurrency, resource and lifecycle controls.
  * Packaging ignore rules to exclude VCS, IDE, backup and temp files from chart packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->