### PR TITLE
fix(ctrlc-sync): missing provider

### DIFF
--- a/charts/ctrlc-sync/Chart.yaml
+++ b/charts/ctrlc-sync/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ctrlc-sync
 description: A Helm chart for ctrlc sync jobs in Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "v0.16.2"
 
 maintainers:

--- a/charts/ctrlc-sync/templates/cronjob.yaml
+++ b/charts/ctrlc-sync/templates/cronjob.yaml
@@ -65,7 +65,7 @@ spec:
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               command: ["ctrlc"]
-              args: ["sync", "kubernetes"]
+              args: ["sync", "kubernetes", "--provider={{ .Values.ctrlc.provider }}"]
               env:
                 {{- include "ctrlc-sync.envs" . | nindent 16 }}
               {{- with .Values.resources }}

--- a/charts/ctrlc-sync/values.yaml
+++ b/charts/ctrlc-sync/values.yaml
@@ -1,5 +1,6 @@
 ctrlc:
   target: "kubernetes"
+  provider: ""
   # All of following values under the ctrlc config from this point
   # can be provided directly as strings or as valueFrom
   # reference -> https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#envvarsource-v1-core


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable provider option for the Ctrl-C sync service, allowing selection of the sync provider.

* **Chores**
  * Bumped Helm chart version to 0.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->