### PR TITLE
fix: ctrlc doesn't do cluster-name env detection

### DIFF
--- a/charts/ctrlc-sync/Chart.yaml
+++ b/charts/ctrlc-sync/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ctrlc-sync
 description: A Helm chart for ctrlc sync jobs in Kubernetes
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "0.16.3"
 
 maintainers:

--- a/charts/ctrlc-sync/templates/cronjob.yaml
+++ b/charts/ctrlc-sync/templates/cronjob.yaml
@@ -65,7 +65,7 @@ spec:
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               command: ["ctrlc"]
-              args: ["sync", "kubernetes", "--provider={{ .Values.ctrlc.provider }}"]
+              args: ["sync", "kubernetes", "--provider={{ .Values.ctrlc.provider }}", "--cluster-name={{ .Values.ctrlc.name }}"]
               env:
                 {{- include "ctrlc-sync.envs" . | nindent 16 }}
               {{- with .Values.resources }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Helm chart version updated to 0.1.4

* **New Features**
  * Added cluster name parameter to sync service configuration for multi-cluster deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->