### PR TITLE
feat(otel): Adds envVars to otel pods and deployment option

### DIFF
--- a/charts/ctrlplane/Chart.lock
+++ b/charts/ctrlplane/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.1.6
 - name: otel
   repository: file://charts/otel
-  version: 0.1.0
+  version: 0.2.0
 - name: wandb-base
   repository: https://charts.wandb.ai
   version: 0.11.11
@@ -14,5 +14,5 @@ dependencies:
 - name: wandb-base
   repository: https://charts.wandb.ai
   version: 0.11.11
-digest: sha256:a15f24e455ca221b9506bdf09b33917224777f4ea68bb4e89a8eb794fbcb89e0
-generated: "2026-03-11T18:06:48.680888-04:00"
+digest: sha256:11be9c366718847a7f76355f54f3816cd7223e2d9feb63a28d90e6397ad0cc50
+generated: "2026-04-13T16:19:18.331308-05:00"

--- a/charts/ctrlplane/Chart.yaml
+++ b/charts/ctrlplane/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ctrlplane
 description: Ctrlplane Helm chart for Kubernetes
 type: application
-version: 1.0.2
+version: 1.1.0
 appVersion: 1.0.0
 
 maintainers:

--- a/charts/ctrlplane/charts/otel/Chart.yaml
+++ b/charts/ctrlplane/charts/otel/Chart.yaml
@@ -3,5 +3,5 @@ name: otel
 type: application
 description: A Helm chart for Kubernetes
 
-version: 0.1.0
+version: 0.2.0
 appVersion: "0.109.0"

--- a/charts/ctrlplane/charts/otel/templates/_config.tpl
+++ b/charts/ctrlplane/charts/otel/templates/_config.tpl
@@ -51,8 +51,10 @@ processors:
     limit_percentage: 80
     spike_limit_percentage: 25
   k8sattributes:
+    {{- if ne (default "DaemonSet" .Values.workload.kind) "Deployment" }}
     filter:
       node_from_env_var: K8S_NODE_NAME
+    {{- end }}
     passthrough: false
     pod_association:
     - sources:

--- a/charts/ctrlplane/charts/otel/templates/_podtemplate.tpl
+++ b/charts/ctrlplane/charts/otel/templates/_podtemplate.tpl
@@ -1,0 +1,68 @@
+{{- define "otel.podTemplate" }}
+    metadata:
+      labels:
+        {{- include "otel.commonLabels" . | nindent 8 }}
+        {{- include "otel.podLabels" . | nindent 8 }}
+        {{- include "otel.labels" . | nindent 8 }}
+      annotations:
+        checksum/configmap: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum | trunc 63 }}
+        {{- if .Values.pod.annotations }}
+        {{-   toYaml .Values.pod.annotations | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "otel.serviceAccountName" . }}
+      {{- if .Values.tolerations }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
+      {{- include "ctrlplane.nodeSelector" . | nindent 6 }}
+      {{- include "ctrlplane.priorityClassName" . | nindent 6 }}
+      {{- include "ctrlplane.podSecurityContext" .Values.pod.securityContext | nindent 6 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          command:
+            - /otelcol-contrib
+            - --config=/conf/config.yaml
+          ports:
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+            - name: prometheus
+              containerPort: 9109
+              protocol: TCP
+            - name: statsd
+              containerPort: 8125
+              protocol: TCP
+          env:
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            {{- range $name, $ref := .Values.extraEnvFrom }}
+            - name: {{ $name }}
+              valueFrom:
+                {{- toYaml $ref | nindent 16 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /conf
+              name: config
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "otel.fullname" . }}
+            items:
+              - key: config
+                path: config.yaml
+      hostNetwork: false
+{{- end }}

--- a/charts/ctrlplane/charts/otel/templates/daemonset.yaml
+++ b/charts/ctrlplane/charts/otel/templates/daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if ne (default "DaemonSet" .Values.workload.kind) "Deployment" }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -17,64 +18,5 @@ spec:
       {{- include "ctrlplane.selectorLabels" $ | nindent 6 }}
       {{- include "otel.labels" . | nindent 6 }}
   template:
-    metadata:
-      labels:
-        {{- include "otel.commonLabels" . | nindent 8 }}
-        {{- include "otel.podLabels" . | nindent 8 }}
-        {{- include "otel.labels" . | nindent 8 }}
-      annotations:
-        checksum/configmap: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum | trunc 63 }}
-        {{- if .Values.pod.annotations -}}
-        {{-   toYaml .Values.pod.annotations | nindent 4 }}
-        {{- end }}
-    spec:
-      serviceAccountName: {{ include "otel.serviceAccountName" . }}
-      {{- if .Values.tolerations }}
-      tolerations:
-        {{- toYaml .Values.tolerations | nindent 8 }}
-      {{- end }}
-      {{- include "ctrlplane.nodeSelector" . | nindent 6 }}
-      {{- include "ctrlplane.priorityClassName" . | nindent 6 }}
-      {{- include "ctrlplane.podSecurityContext" .Values.pod.securityContext | nindent 6 }}
-      containers:
-        - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          command:
-            - /otelcol-contrib
-            - --config=/conf/config.yaml
-          ports:
-            - name: otlp
-              containerPort: 4317
-              protocol: TCP
-            - name: otlp-http
-              containerPort: 4318
-              protocol: TCP
-            - name: prometheus
-              containerPort: 9109
-              protocol: TCP
-            - name: statsd
-              containerPort: 8125
-              protocol: TCP
-          env:
-            - name: K8S_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
-          resources:
-            {{- toYaml .Values.resources | nindent 12 }}
-          volumeMounts:
-            - mountPath: /conf
-              name: config
-      volumes:
-        - name: config
-          configMap:
-            name: {{ include "otel.fullname" . }}
-            items:
-              - key: config
-                path: config.yaml
-      hostNetwork: false
+{{ include "otel.podTemplate" . }}
+{{- end }}

--- a/charts/ctrlplane/charts/otel/templates/deployment.yaml
+++ b/charts/ctrlplane/charts/otel/templates/deployment.yaml
@@ -1,0 +1,29 @@
+{{- if eq (default "DaemonSet" .Values.workload.kind) "Deployment" }}
+{{- $deploy := default dict .Values.deployment }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "otel.fullname" . }}
+  labels:
+    {{- include "otel.labels" . | nindent 4 }}
+    {{- if $deploy.labels -}}
+    {{-   toYaml $deploy.labels | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if $deploy.annotations -}}
+    {{-   toYaml $deploy.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  replicas: {{ $deploy.replicas | default 2 }}
+  revisionHistoryLimit: {{ $deploy.revisionHistoryLimit | default 10 }}
+  {{- if $deploy.strategy }}
+  strategy:
+    {{- toYaml $deploy.strategy | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "ctrlplane.selectorLabels" $ | nindent 6 }}
+      {{- include "otel.labels" . | nindent 6 }}
+  template:
+{{ include "otel.podTemplate" . }}
+{{- end }}

--- a/charts/ctrlplane/charts/otel/values.yaml
+++ b/charts/ctrlplane/charts/otel/values.yaml
@@ -1,6 +1,24 @@
 nameOverride: ""
 fullnameOverride: ""
 
+# "DaemonSet" (default): one collector per node, needed for host-level
+# receivers (hostMetrics, logsCollection, kubeletMetrics).
+# "Deployment": central collector behind the Service, suitable when only
+# network receivers (otlp, statsd) are used.
+workload:
+  kind: DaemonSet
+
+# deployment:
+#   replicas: 2
+#   revisionHistoryLimit: 10
+#   strategy:
+#     type: RollingUpdate
+#     rollingUpdate:
+#       maxSurge: 1
+#       maxUnavailable: 0
+#   labels: {}
+#   annotations: {}
+
 config:
   service:
     pipelines:
@@ -27,6 +45,15 @@ image:
 
 # Tolerations for pod scheduling
 tolerations: []
+
+# Extra environment variables sourced from Secrets/ConfigMaps.
+# Example:
+#   extraEnvFrom:
+#     DD_API_KEY:
+#       secretKeyRef:
+#         name: my-secret
+#         key: api-key
+extraEnvFrom: {}
 
 extraCors: []
 


### PR DESCRIPTION
Adds optional Deployment workload mode for otel pods instead of using DaemonSet. This is useful for clusters where node-level telemetry (host metrics, log collection, kubelet scraping) is not needed.

When workload.kind is set to Deployment, the k8sattributes processor omits the node-scoped filter so pod enrichment works cluster-wide.

Adds extraEnvFrom to pod templates to allow injecting credentials from Kubernetes secrets (e.g. DD_API_KEY).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deploying OpenTelemetry as a Deployment workload (alternative to DaemonSet mode).
  * Added ability to inject additional environment variables into the OpenTelemetry collector.

* **Chores**
  * Updated Helm chart versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->