### PR TITLE
fix: use otel selector labels instead of regular labels for proper trace wiring

### DIFF
--- a/charts/ctrlplane/Chart.lock
+++ b/charts/ctrlplane/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.1.6
 - name: otel
   repository: file://charts/otel
-  version: 0.2.0
+  version: 0.2.1
 - name: wandb-base
   repository: https://charts.wandb.ai
   version: 0.11.11
@@ -14,5 +14,5 @@ dependencies:
 - name: wandb-base
   repository: https://charts.wandb.ai
   version: 0.11.11
-digest: sha256:11be9c366718847a7f76355f54f3816cd7223e2d9feb63a28d90e6397ad0cc50
-generated: "2026-04-13T16:19:18.331308-05:00"
+digest: sha256:03b431cdd1b20c20d969b0eacb90e33dec92599d877dde63f801f2fa926b8d86
+generated: "2026-05-04T13:22:49.464936-04:00"

--- a/charts/ctrlplane/Chart.yaml
+++ b/charts/ctrlplane/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ctrlplane
 description: Ctrlplane Helm chart for Kubernetes
 type: application
-version: 1.1.1
+version: 1.1.2
 appVersion: 1.0.0
 
 maintainers:

--- a/charts/ctrlplane/charts/otel/Chart.yaml
+++ b/charts/ctrlplane/charts/otel/Chart.yaml
@@ -3,5 +3,5 @@ name: otel
 type: application
 description: A Helm chart for Kubernetes
 
-version: 0.2.0
+version: 0.2.1
 appVersion: "0.109.0"

--- a/charts/ctrlplane/charts/otel/templates/daemonset.yaml
+++ b/charts/ctrlplane/charts/otel/templates/daemonset.yaml
@@ -15,8 +15,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "ctrlplane.selectorLabels" $ | nindent 6 }}
-      {{- include "otel.labels" . | nindent 6 }}
+      {{- include "otel.selectorLabels" . | nindent 6 }}
   template:
 {{ include "otel.podTemplate" . }}
 {{- end }}

--- a/charts/ctrlplane/charts/otel/templates/deployment.yaml
+++ b/charts/ctrlplane/charts/otel/templates/deployment.yaml
@@ -22,8 +22,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "ctrlplane.selectorLabels" $ | nindent 6 }}
-      {{- include "otel.labels" . | nindent 6 }}
+      {{- include "otel.selectorLabels" . | nindent 6 }}
   template:
 {{ include "otel.podTemplate" . }}
 {{- end }}

--- a/charts/ctrlplane/charts/otel/templates/service.yaml
+++ b/charts/ctrlplane/charts/otel/templates/service.yaml
@@ -32,4 +32,4 @@ spec:
       protocol: TCP
       name: otlp-http
   selector:
-    {{- include "otel.labels" . | nindent 4 }}
+    {{- include "otel.selectorLabels" . | nindent 4 }}

--- a/charts/ctrlplane/tests/otel_selector_test.yaml
+++ b/charts/ctrlplane/tests/otel_selector_test.yaml
@@ -1,0 +1,54 @@
+suite: otel selectors are stable across chart versions
+templates:
+  - charts/otel/templates/daemonset.yaml
+  - charts/otel/templates/deployment.yaml
+  - charts/otel/templates/service.yaml
+  - charts/otel/templates/configmap.yaml
+release:
+  name: ctrlplane
+
+tests:
+  - it: daemonset selector contains only stable identity labels
+    template: charts/otel/templates/daemonset.yaml
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: otel
+            app.kubernetes.io/instance: ctrlplane
+
+  - it: daemonset pod labels still include chart-version labels
+    template: charts/otel/templates/daemonset.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: otel
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/instance"]
+          value: ctrlplane
+      - exists:
+          path: spec.template.metadata.labels["helm.sh/chart"]
+      - exists:
+          path: spec.template.metadata.labels["ctrlplane.com/app-name"]
+
+  - it: deployment selector contains only stable identity labels
+    template: charts/otel/templates/deployment.yaml
+    set:
+      otel:
+        workload:
+          kind: Deployment
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: otel
+            app.kubernetes.io/instance: ctrlplane
+
+  - it: service selector contains only stable identity labels
+    template: charts/otel/templates/service.yaml
+    asserts:
+      - equal:
+          path: spec.selector
+          value:
+            app.kubernetes.io/name: otel
+            app.kubernetes.io/instance: ctrlplane


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Version Updates**
  * Main Helm chart bumped to v1.1.2
  * OpenTelemetry sub-chart bumped to v0.2.1

* **Improvements**
  * Standardized Kubernetes selector labels for OpenTelemetry DaemonSet, Deployment, and Service components

* **Tests**
  * Added test suite validating selector label stability across chart versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->