### PR TITLE
chore(otel): Ensure daemonset uses local policy

### DIFF
--- a/charts/ctrlplane/Chart.lock
+++ b/charts/ctrlplane/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.1.6
 - name: otel
   repository: file://charts/otel
-  version: 0.2.1
+  version: 0.2.2
 - name: wandb-base
   repository: https://charts.wandb.ai
   version: 0.11.11
@@ -14,5 +14,5 @@ dependencies:
 - name: wandb-base
   repository: https://charts.wandb.ai
   version: 0.11.11
-digest: sha256:03b431cdd1b20c20d969b0eacb90e33dec92599d877dde63f801f2fa926b8d86
-generated: "2026-05-04T13:22:49.464936-04:00"
+digest: sha256:f1eac868446cb9d10c2be8327207e72acda8c5136350a5a4b271463b25cc348b
+generated: "2026-05-08T15:38:09.858607-05:00"

--- a/charts/ctrlplane/Chart.yaml
+++ b/charts/ctrlplane/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ctrlplane
 description: Ctrlplane Helm chart for Kubernetes
 type: application
-version: 1.1.2
+version: 1.1.3
 appVersion: 1.0.0
 
 maintainers:

--- a/charts/ctrlplane/charts/otel/Chart.yaml
+++ b/charts/ctrlplane/charts/otel/Chart.yaml
@@ -3,5 +3,5 @@ name: otel
 type: application
 description: A Helm chart for Kubernetes
 
-version: 0.2.1
+version: 0.2.2
 appVersion: "0.109.0"

--- a/charts/ctrlplane/charts/otel/templates/service.yaml
+++ b/charts/ctrlplane/charts/otel/templates/service.yaml
@@ -18,6 +18,9 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if eq (default "DaemonSet" .Values.workload.kind) "DaemonSet" }}
+  internalTrafficPolicy: Local
+  {{- end }}
   ports:
     - port: 9109
       protocol: TCP

--- a/charts/ctrlplane/tests/otel_internal_traffic_policy_test.yaml
+++ b/charts/ctrlplane/tests/otel_internal_traffic_policy_test.yaml
@@ -1,0 +1,31 @@
+suite: otel service internalTrafficPolicy is set for DaemonSet only
+templates:
+  - charts/otel/templates/service.yaml
+release:
+  name: ctrlplane
+
+tests:
+  - it: service has internalTrafficPolicy=Local in default (DaemonSet) mode
+    asserts:
+      - equal:
+          path: spec.internalTrafficPolicy
+          value: Local
+
+  - it: service has internalTrafficPolicy=Local when workload.kind is set explicitly to DaemonSet
+    set:
+      otel:
+        workload:
+          kind: DaemonSet
+    asserts:
+      - equal:
+          path: spec.internalTrafficPolicy
+          value: Local
+
+  - it: service does NOT set internalTrafficPolicy when workload.kind is Deployment
+    set:
+      otel:
+        workload:
+          kind: Deployment
+    asserts:
+      - notExists:
+          path: spec.internalTrafficPolicy


### PR DESCRIPTION
We run OTEL as a DaemonSet. When spans hit the collector, it uses the pod's IP as a cache key to lookup the pods information and get all the details like namespace, deployment, etc. We set the OTEL collector endpoint to `OTEL_EXPORTER_OTLP_ENDPOINT=http://ctrlplane-otel:4318` which hits the Service. By default, the Service traffic policy will load balance traffic to pods on different nodes. So when a span from node A hits a OTEL pod in node B, the pod IP is a cache miss and we don't get the enriched details. In that case, the spans look like this (see only pod IP is there)

## Using Default Cluster mode
<img width="721" height="866" alt="Screenshot 2026-05-08 at 2 37 05 PM" src="https://github.com/user-attachments/assets/e839c585-0627-4751-9b7e-0d74c19a1aaf" />

When fixed to use `Local` traffic policy, the Service sends traffic to the pods on the same node as the caller. This is more efficient and causes the cache to properly return the pod data. See the results here with full k8s info

## Using Correct Local mode
<img width="721" height="866" alt="Screenshot 2026-05-08 at 2 36 30 PM" src="https://github.com/user-attachments/assets/3e3a6ef8-576a-48a8-8764-6cefcf827529" />

This PR defaults traffic policy to Local when it runs as a DaemonSet as is the proper config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ctrlplane chart to version 1.1.3
  * Updated OTEL chart to version 0.2.2
  * Optimized OTEL service traffic routing for DaemonSet deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->