### PR TITLE
chore: Add leader election for cluster metrics

### DIFF
--- a/charts/ctrlplane/Chart.lock
+++ b/charts/ctrlplane/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.1.6
 - name: otel
   repository: file://charts/otel
-  version: 0.2.2
+  version: 0.2.3
 - name: wandb-base
   repository: https://charts.wandb.ai
   version: 0.11.11
@@ -14,5 +14,5 @@ dependencies:
 - name: wandb-base
   repository: https://charts.wandb.ai
   version: 0.11.11
-digest: sha256:f1eac868446cb9d10c2be8327207e72acda8c5136350a5a4b271463b25cc348b
-generated: "2026-05-08T15:38:09.858607-05:00"
+digest: sha256:72e6062b790e1d667365e54d31762af5ae4a16cddb4422a697843329ef6863a0
+generated: "2026-05-11T10:43:19.537489-05:00"

--- a/charts/ctrlplane/Chart.yaml
+++ b/charts/ctrlplane/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ctrlplane
 description: Ctrlplane Helm chart for Kubernetes
 type: application
-version: 1.1.3
+version: 1.1.4
 appVersion: 1.0.0
 
 maintainers:

--- a/charts/ctrlplane/charts/otel/Chart.yaml
+++ b/charts/ctrlplane/charts/otel/Chart.yaml
@@ -3,5 +3,5 @@ name: otel
 type: application
 description: A Helm chart for Kubernetes
 
-version: 0.2.2
+version: 0.2.3
 appVersion: "0.109.0"

--- a/charts/ctrlplane/charts/otel/templates/_config.tpl
+++ b/charts/ctrlplane/charts/otel/templates/_config.tpl
@@ -41,6 +41,12 @@ exporters:
 {{- define "otel.extensions" -}}
 extensions:
   health_check: {}
+  {{- if .Values.presets.receivers.kubernetesCluster }}
+  k8s_leader_elector:
+    auth_type: serviceAccount
+    lease_name: {{ include "otel.fullname" . }}-leader
+    lease_namespace: {{ .Release.Namespace }}
+  {{- end }}
 {{- end }}
 
 {{- define "otel.processors" -}}
@@ -91,6 +97,9 @@ processors:
 service:
   extensions:
   - health_check
+  {{- if .Values.presets.receivers.kubernetesCluster }}
+  - k8s_leader_elector
+  {{- end }}
   pipelines: {}
   telemetry:
     metrics:

--- a/charts/ctrlplane/charts/otel/templates/_receivers.tpl
+++ b/charts/ctrlplane/charts/otel/templates/_receivers.tpl
@@ -159,6 +159,7 @@ receivers:
 receivers:
   k8s_cluster:
     collection_interval: 10s
+    k8s_leader_elector: k8s_leader_elector
 {{- end }}
 
 {{- define "otel.statsdReceiver" -}}

--- a/charts/ctrlplane/charts/otel/templates/clusterrole.yaml
+++ b/charts/ctrlplane/charts/otel/templates/clusterrole.yaml
@@ -52,3 +52,8 @@ rules:
   - apiGroups: ["events.k8s.io"]
     resources: ["events"]
     verbs: ["watch", "list"]
+
+  # leaderElection (k8s_leader_elector extension)
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/charts/ctrlplane/tests/otel_leader_election_test.yaml
+++ b/charts/ctrlplane/tests/otel_leader_election_test.yaml
@@ -1,0 +1,64 @@
+suite: otel leader election wiring for k8s_cluster receiver
+release:
+  name: ctrlplane
+  namespace: ctrlplane
+
+tests:
+  - it: clusterrole grants leases permissions (always — preset-independent)
+    template: charts/otel/templates/clusterrole.yaml
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["coordination.k8s.io"]
+            resources: ["leases"]
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  - it: configmap does NOT include k8s_leader_elector when kubernetesCluster preset is off (default)
+    template: charts/otel/templates/configmap.yaml
+    asserts:
+      - notMatchRegex:
+          path: data.config
+          pattern: 'k8s_leader_elector'
+
+  - it: configmap includes k8s_leader_elector extension when kubernetesCluster preset is on
+    template: charts/otel/templates/configmap.yaml
+    set:
+      otel:
+        presets:
+          receivers:
+            kubernetesCluster: true
+    asserts:
+      - matchRegex:
+          path: data.config
+          pattern: 'k8s_leader_elector:\s+auth_type: serviceAccount'
+      - matchRegex:
+          path: data.config
+          pattern: 'lease_name: ctrlplane-otel-leader'
+      - matchRegex:
+          path: data.config
+          pattern: 'lease_namespace: ctrlplane'
+
+  - it: k8s_cluster receiver references the elector when kubernetesCluster preset is on
+    template: charts/otel/templates/configmap.yaml
+    set:
+      otel:
+        presets:
+          receivers:
+            kubernetesCluster: true
+    asserts:
+      - matchRegex:
+          path: data.config
+          pattern: 'k8s_cluster:[\s\S]*k8s_leader_elector: k8s_leader_elector'
+
+  - it: service.extensions includes k8s_leader_elector when kubernetesCluster preset is on
+    template: charts/otel/templates/configmap.yaml
+    set:
+      otel:
+        presets:
+          receivers:
+            kubernetesCluster: true
+    asserts:
+      - matchRegex:
+          path: data.config
+          pattern: 'extensions:\s*\n\s+- health_check\s*\n\s+- k8s_leader_elector'


### PR DESCRIPTION
The OTeL collector runs with one pod per node. If we enable cluster metrics as is, each node would report the same metrics and we would have duplicate numbers. In order to avoid duplicates, we can use the leader election extension for OTeL. This will elect a single leader from the DaemonSet to report cluster metrics and will prevent duplicate reporting. 

An alternative would be to make a separate single-replica deployment for just cluster metrics, but that would require a larger change and this leader election fits nicely into our existing charts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OpenTelemetry leader election support for Kubernetes cluster receivers.

* **Chores**
  * Incremented chart versions to reflect configuration updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ctrlplanedev/ctrlcharts/pull/42)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->