### PR TITLE
chore: Bump otel image version

### DIFF
--- a/charts/ctrlplane/Chart.lock
+++ b/charts/ctrlplane/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.1.6
 - name: otel
   repository: file://charts/otel
-  version: 0.2.3
+  version: 0.2.4
 - name: wandb-base
   repository: https://charts.wandb.ai
   version: 0.11.11
@@ -14,5 +14,5 @@ dependencies:
 - name: wandb-base
   repository: https://charts.wandb.ai
   version: 0.11.11
-digest: sha256:72e6062b790e1d667365e54d31762af5ae4a16cddb4422a697843329ef6863a0
-generated: "2026-05-11T10:43:19.537489-05:00"
+digest: sha256:197bab84c00caf3fc6f5bfff19687da5f658abdd45c1938dfcd78bb0f1595770
+generated: "2026-05-11T14:35:47.343908-05:00"

--- a/charts/ctrlplane/Chart.yaml
+++ b/charts/ctrlplane/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ctrlplane
 description: Ctrlplane Helm chart for Kubernetes
 type: application
-version: 1.1.4
+version: 1.1.5
 appVersion: 1.0.0
 
 maintainers:

--- a/charts/ctrlplane/charts/otel/Chart.yaml
+++ b/charts/ctrlplane/charts/otel/Chart.yaml
@@ -3,5 +3,5 @@ name: otel
 type: application
 description: A Helm chart for Kubernetes
 
-version: 0.2.3
-appVersion: "0.109.0"
+version: 0.2.4
+appVersion: "0.126.0"

--- a/charts/ctrlplane/charts/otel/values.yaml
+++ b/charts/ctrlplane/charts/otel/values.yaml
@@ -39,7 +39,7 @@ presets:
 
 image:
   repository: otel/opentelemetry-collector-contrib
-  tag: 0.112.0
+  tag: 0.126.0
   pullPolicy: IfNotPresent
   # pullSecrets: []
 


### PR DESCRIPTION
The k8s leader election extension added here: https://github.com/ctrlplanedev/ctrlcharts/pull/42 needs a newer version of OTEL image. The leader extension was added in 0.126.0. Bumping the default version to pick up that change. Confirmed it works in QA ctrlplane by overriding the image tag to this one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart versions for ctrlplane and OpenTelemetry components.
  * Upgraded OpenTelemetry Collector to version 0.126.0.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ctrlplanedev/ctrlcharts/pull/43)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->